### PR TITLE
Remove Jekyll and add 404 fallback in workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Add .nojekyll and fallback 404
         run: |
-          touch .nojekyll
+          touch dist/.nojekyll
           cp dist/index.html dist/404.html
 
       - name: Deploy 🚀

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -25,10 +25,18 @@ jobs:
           target: wasm32-unknown-unknown
       - uses: cargo-bins/cargo-binstall@main
       - uses: Swatinem/rust-cache@v1
+
       - name: Install CLI
         run: cargo binstall --no-confirm dioxus-cli --locked --force
+
       - name: Build
         run: dx build --release
+
+      - name: Add .nojekyll and fallback 404
+        run: |
+          touch .nojekyll
+          cp dist/index.html dist/404.html
+
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4.2.3
         with:

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: minima


### PR DESCRIPTION
- Removes the unnecessary `_config.yml` file, instead adding a `dist/.nojekyll` file in the workflow which tells GitHub Pages to not treat this as a Jekyll project.
- Adds `dist/404.html`, which is a copy of `dist/index.html`. This is necessary for Single Page Apps (like Dioxus) to work properly. For example, `dioxus-community.github.io/made-with-dioxus` would return `404` if the user didn't first go to `dioxus-community.github.io`, because `/made-with-dioxus` is not a route on the server. Copying `index.html` to the 404 fallback, in this case `404.html`, fixes that.